### PR TITLE
Rename Maven group to jfixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Import it into maven as so:
 
 ```xml
 <dependency>
-	<groupId>com.flextrade.kfixture</groupId>
+	<groupId>com.flextrade.jfixture</groupId>
 	<artifactId>kfixture</artifactId>
 	<version>1.0.0</version>
 	<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.flextrade.kfixture</groupId>
+    <groupId>com.flextrade.jfixture</groupId>
     <artifactId>kfixture</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 


### PR DESCRIPTION
To get this published to Sonatype OSS repositories, we'll use the same Maven group as jfixture